### PR TITLE
Make toolchain Modder proceed ahead to VersionSuffix

### DIFF
--- a/src/main/java/com/redhat/rcm/version/mgr/mod/ProjectModder.java
+++ b/src/main/java/com/redhat/rcm/version/mgr/mod/ProjectModder.java
@@ -29,7 +29,7 @@ public interface ProjectModder
 
     String[] STANDARD_MODIFICATIONS = {"version-suffix", "toolchain-realignment", "bom-realignment", "repo-removal" };
 
-    String[] MODIFICATION_ORDER = { "toolchain-realignment", "version-suffix", "version" };
+    String[] MODIFICATION_ORDER = { "toolchain-realignment", "version-suffix", "version", "bom-realignment" };
 
     Comparator<String> KEY_COMPARATOR = new Comparator<String>()
     {


### PR DESCRIPTION
I run vman on modeshape (git://github.com/ModeShape/modeshape.git 3.0.0.Final) and get error report like [1]
I think this error can be avoid by adjusting the modder order as toolchain->versionsuffix->version.

soa-toolchain is actually specified as toolcain in vman.properites. and should not report. as "Not specified in a BOM". Notice that the origin existed parent is jboss-parent and vman  check "jboss-parent " not equal "soa-toolchain" , so report the issue . I think that make the toolchainmodder the first one  proceed can fix this issue.

[1]
0: com.redhat.rcm.version.VManException: The project parent version was NOT specified in a BOM.
Parent: org.jboss.soa:soa-toolchain:0.1-redhat-1
Project: org.modeshape:modeshape-parent:3.0.0.Final-redhat-1
File: /home/rzhang/workspace/modeshape/modeshape-parent/pom.xml

at com.redhat.rcm.version.mgr.verify.VersionSuffixVerifier.verify(VersionSuffixVerifier.java:38)
at com.redhat.rcm.version.mgr.VersionManager.modVersions(VersionManager.java:322)
at com.redhat.rcm.version.mgr.VersionManager.modifyVersions(VersionManager.java:168)
at com.redhat.rcm.version.Cli.run(Cli.java:477)
at com.redhat.rcm.version.Cli.main(Cli.java:267)
