### PR TITLE
Plugin alignment removal

### DIFF
--- a/src/main/java/com/redhat/rcm/version/mgr/mod/ExtensionsRemovalModder.java
+++ b/src/main/java/com/redhat/rcm/version/mgr/mod/ExtensionsRemovalModder.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.mae.project.key.VersionlessProjectKey;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Extension;
 import org.apache.maven.model.Model;
 import org.codehaus.plexus.component.annotations.Component;
@@ -85,6 +86,14 @@ public class ExtensionsRemovalModder
         }
         else
         {
+
+            Build build = model.getBuild();
+            if ( build == null )
+            {
+                build = new Build();
+                model.setBuild( build );
+            }
+
             model.getBuild()
                  .setExtensions( Collections.<Extension> emptyList() );
             changed = true;

--- a/src/main/java/com/redhat/rcm/version/mgr/verify/ToolchainVerifier.java
+++ b/src/main/java/com/redhat/rcm/version/mgr/verify/ToolchainVerifier.java
@@ -31,7 +31,7 @@ import com.redhat.rcm.version.model.Project;
 import com.redhat.rcm.version.util.CollectionToString;
 import com.redhat.rcm.version.util.ObjectToString;
 
-@Component( role = ProjectVerifier.class, hint = "toolchain-realignment" )
+//@Component( role = ProjectVerifier.class, hint = "toolchain-realignment" )
 public class ToolchainVerifier
     implements ProjectVerifier
 {


### PR DESCRIPTION
Since we are not performing plugin alignment anymore, I have commented out the injection of the ToolchainVerifier.
I have also encountered a Null Pointer exception, and managed it the same way as in he ToolchainModder class.
